### PR TITLE
feat: 新增 translations 的參數控制取得資料的語系

### DIFF
--- a/app/controllers/subdivision_select/subdivisions_controller.rb
+++ b/app/controllers/subdivision_select/subdivisions_controller.rb
@@ -1,7 +1,17 @@
 module SubdivisionSelect
   class SubdivisionsController < ApplicationController
     def get
-      render json: SubdivisionsHelper::get_subdivisions(params[:country_code])
+      render json: SubdivisionsHelper::get_subdivisions(params[:country_code], subdivision_option_params)
     end
+
+    private
+
+      def subdivision_option_params
+        return {} if params[:option].nil?
+
+        params.require(:option).permit(
+          :translation
+        )
+      end
   end
 end

--- a/app/helpers/subdivision_select/subdivisions_helper.rb
+++ b/app/helpers/subdivision_select/subdivisions_helper.rb
@@ -1,20 +1,26 @@
 module SubdivisionSelect
   module SubdivisionsHelper
-    def self.get_subdivisions(alpha2)
+
+    DEFAULT_OPTION = {
+      translation: 'zh'
+    }.with_indifferent_access.freeze
+
+    def self.get_subdivisions(alpha2, option = {})
       # The countries gem returns a hash, where:
       # the keys are the ISO 3166-2 subdivision two letter codes
       # and the value is a hash with two key/values:
       # - "name" is the most popular/most correct name
       # - "names" is an array of all the names
+
+      option = DEFAULT_OPTION.merge(option)
+
       if ISO3166::Country[alpha2].nil?
         {}
       else
         subdivisions = ISO3166::Country[alpha2].subdivisions.map do |k, v|
-          value = alpha2 == 'TW' ? v["translations"]["zh"] : v["name"]
-
           [
             k,
-            value
+            v['translations'][option[:translation]] || v['name']
           ]
         end
 
@@ -34,8 +40,8 @@ module SubdivisionSelect
       Rails.root.join('config', 'subdivisions_order.yml')
     end
 
-    def self.get_subdivisions_for_select(alpha2)
-      get_subdivisions(alpha2).invert.to_a
+    def self.get_subdivisions_for_select(alpha2, option = {})
+      get_subdivisions(alpha2, option).invert.to_a
     end
   end
 end

--- a/lib/subdivision_select/tag_helper.rb
+++ b/lib/subdivision_select/tag_helper.rb
@@ -7,9 +7,13 @@ module SubdivisionSelect
         disabled: @options[:disabled]
       }
 
+      subdivisions_option = {}
+
+      subdivisions_option = subdivisions_option.merge(translation: @options[:translation]) if @options[:translation].present?
+
       # Actual loading of subdivisions is in a View helper, since the controller
       # needs to use it, to render the subdivisions of a country in JSON
-      subdivisions = SubdivisionsHelper::get_subdivisions_for_select(country)
+      subdivisions = SubdivisionsHelper::get_subdivisions_for_select(country, subdivisions_option)
       options_for_select(subdivisions, option_tags_options)
     end
 

--- a/lib/subdivision_select/version.rb
+++ b/lib/subdivision_select/version.rb
@@ -1,3 +1,3 @@
 module SubdivisionSelect
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
## 相關 issue

* https://github.com/BackerFounder/backme/issues/9959

## PR 說明

讓 `SubdivisionSelect::SubdivisionsHelper` 底下 `get_subdivisions` 與 `get_subdivisions_for_select` 的方法，可以透過 `translation` 的參數來決定要回傳資料的語系