### PR TITLE
fix: replace deprecated File.exists? with File.exist?

### DIFF
--- a/app/helpers/subdivision_select/subdivisions_helper.rb
+++ b/app/helpers/subdivision_select/subdivisions_helper.rb
@@ -29,7 +29,7 @@ module SubdivisionSelect
     end
 
     def self.order_subdivisions(subdivisions)
-      return subdivisions.to_h unless File.exists?(reference_source_path)
+      return subdivisions.to_h unless File.exist?(reference_source_path)
 
       reference_order = YAML.load_file(reference_source_path)
 

--- a/lib/subdivision_select/version.rb
+++ b/lib/subdivision_select/version.rb
@@ -1,3 +1,3 @@
 module SubdivisionSelect
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
在 backme repo 升級 ruby 3 的時候看到 warning
`File.exists? is deprecated; use File.exist? instead`