### PR TITLE
升級到 rails 7.1

### DIFF
--- a/lib/subdivision_select/subdivision_select_helper.rb
+++ b/lib/subdivision_select/subdivision_select_helper.rb
@@ -36,7 +36,7 @@ module ActionView
 
     module Tags
       # TODO: can we inherit from Select?
-      class SubdivisionSelect < Base
+      class SubdivisionSelect < Select
         include ::SubdivisionSelect::TagHelper
 
         def initialize(object_name, method_name, template_object, options, html_options)

--- a/lib/subdivision_select/version.rb
+++ b/lib/subdivision_select/version.rb
@@ -1,3 +1,3 @@
 module SubdivisionSelect
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/subdivision_select.gemspec
+++ b/subdivision_select.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   ]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 4.1"
+  s.add_dependency "rails", ">= 7.1"
   s.add_dependency "country_select", "~> 4.0"
   s.add_dependency "countries", "~> 3.0"
   s.add_dependency "jquery-rails", ">= 3.0"


### PR DESCRIPTION
升級到 rails 7.1 版本

## Breaking Change
升級到 7.1 之後會發生 no method error 'options_for_select' 的問題，因為在 7.0.8
`FormOptionsHelper` 是在 `ActionView::Helpers::Tags::Base`
https://github.com/rails/rails/blob/v7.0.8/actionview/lib/action_view/helpers/tags/base.rb#L8C17-L8C34

可是升級到 7.1 可以看到他消失了😏
https://github.com/rails/rails/blob/v7.1.0/actionview/lib/action_view/helpers/tags/base.rb#L8
變成是在 `ActionView::Helpers::Tags::Select` 這邊引入
https://github.com/rails/rails/blob/v7.1.0/actionview/lib/action_view/helpers/tags/select.rb#L8

所以在這個版本去修改繼承的物件，不過並沒有實作 choices 參數功能，先給他個 `{}` 不然要調整現有介面也是個大工程，先讓功能可以運作為主